### PR TITLE
adding a 'repo' install option for splunkforwarder

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,8 @@ default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 
 default['splunk']['server']['runasroot'] = true
 
+default['splunk']['repo_install'] = false
+
 case node['platform_family']
 when 'rhel'
   if node['kernel']['machine'] == 'x86_64'


### PR DESCRIPTION
I changed "simple_install" to "repo_install" it's more descriptive